### PR TITLE
Allow to overwrite events for collections as well

### DIFF
--- a/react.backbone.js
+++ b/react.backbone.js
@@ -15,8 +15,9 @@
             }
             // Detect if it's a collection
             if (model instanceof Backbone.Collection) {
+                var changeOptions = this.changeOptions || 'add remove reset sort';
                 var _throttledForceUpdate = _.throttle(this.forceUpdate.bind(this, null),  500);
-                model.on('add remove reset sort', _throttledForceUpdate, this);
+                model.on(changeOptions, _throttledForceUpdate, this);
             }
             else if (model) {
                 var changeOptions = this.changeOptions || 'change';


### PR DESCRIPTION
Sometimes I need to change my collection on sync for instance (to switch between a loading view and an empty view for instance). This way one can overwrite the events in the same way one can overwrite the model events we listen to.
