### PR TITLE
Add `changeModel` lifecycle methods to React

### DIFF
--- a/react.backbone.js
+++ b/react.backbone.js
@@ -38,6 +38,17 @@
             if (this.props.model !== nextProps.model) {
                 this._unsubscribe(this.props.model);
                 this._subscribe(nextProps.model);
+
+                if (typeof this.componentWillChangeModel === 'function') {
+                    this.componentWillChangeModel();
+                }
+            }
+        },
+        componentDidUpdate: function(prevProps, prevState) {
+            if (this.props.model !== prevProps.model) {
+                if (typeof this.componentDidChangeModel === 'function') {
+                    this.componentDidChangeModel();
+                }
             }
         },
         componentWillUnmount: function() {


### PR DESCRIPTION
Given [this basic example](https://gist.github.com/EtienneLem/62e02d28eec6a7064ec1).
## Before

``` rb
- click "show model 1"
# => c1 componentDidMount

- click "update model 1"
# => c1 componentDidUpdate

- click "show model 2"
# => c2 componentDidUpdate

- click "update model 2"
# => c2 componentDidUpdate
```

**The problem:** I need to be able to store `c1` data when clicking another model (but it’ll never be unmounted). `componentDidUpdate` isn’t the lifecycle method that I’m looking for. I also need to be able to restore `c1` data when navigating back to it (hence the before and after change hooks (see bellow)).
## After

``` rb
- click "show model 1"
# => c1 componentDidMount

- click "update model 1"
# => c1 componentDidUpdate

- click "show model 2"
# => c1 componentWillChangeModel (Note: before change hook)
# => c2 componentDidUpdate
# => c2 componentDidChangeModel (Note: after change hook)

- click "update model 2"
# => c2 componentDidUpdate
```

In other words, these kinda are sort of `mount` & `unmount` lifecycle methods for component that will never `unmount` even when rendering a new model.
