### PR TITLE
Added Commonjs Support.

### DIFF
--- a/react.backbone.js
+++ b/react.backbone.js
@@ -1,5 +1,8 @@
 (function (root, factory) {
-    if (typeof define === 'function' && define.amd) {
+    if (typeof exports === 'object') {
+        // CommonJS
+        module.exports = factory(require('backbone'), require('react'));
+    } else if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['backbone', 'react'], factory);
     } else {


### PR DESCRIPTION
Both Backbone and React are easily found on npm and support the commonjs module format.
By adding a couple of lines react.backbone now works as a commonjs module and can be used with browserify etc.
