### PR TITLE
Added Common.js Support and underscore dependency

### DIFF
--- a/react.backbone.js
+++ b/react.backbone.js
@@ -1,12 +1,15 @@
 (function (root, factory) {
-    if (typeof define === 'function' && define.amd) {
+    if (typeof exports === 'object') {
+        // CommonJS
+        module.exports = factory(require('backbone'), require('react'), require('underscore'));
+    } else if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
-        define(['backbone', 'react'], factory);
+        define(['backbone', 'react', 'underscore'], factory);
     } else {
         // Browser globals
-        root.amdWeb = factory(root.Backbone, root.React);
+        root.amdWeb = factory(root.Backbone, root.React, root._);
     }
-}(this, function (Backbone, React) {
+}(this, function (Backbone, React, _) {
 
     React.BackboneMixin = {
         _subscribe: function(model) {


### PR DESCRIPTION
The factory function was using underscore without requiring it. That wouldn't work with commonjs and AMD.
