### PR TITLE
Add option to use a callback to retrieve a model or collection from the component’s props

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,26 @@ var CommentView = React.createBackboneClass({
 });
 ```
 
+You can also pass an object with options to the included mixin:
+
+```javascript
+React.BackboneMixin({
+    propName: "user",
+    renderOn: "change:name"
+});
+```
+
+Or supply a custom callback to the option `modelOrCollection` to retrieve the
+property from the component's props:
+
+```javascript
+React.BackboneMixin({
+    modelOrCollection: function(props) {
+        return props.comment.user;
+    },
+    renderOn: "change:name"
+});
+```
 
 ### Installation
 


### PR DESCRIPTION
This feature allows you to specify a callback to retrieve the Backbone model or collection to listen to.

Some of our models have a model defined as a property. This method allows you to listen for changes on those models as well.

Example:

``` javascript
var CommentView = React.createBackboneClass({
    mixins: [
        React.BackboneMixin("comment"),
        React.BackboneMixin(function(props) {
            return props.comment.user;
        })
    ],
    render: function() {
        return (
          <div>
              <p>{this.props.comment.get("text")}</p>
              <p>{'posted by' + this.props.comment.user.get("name")}</h1>
          </div>
        );
    }
});
```
