### PR TITLE
Add render to changeOptions

### DIFF
--- a/__tests__/react.backbone-test.js
+++ b/__tests__/react.backbone-test.js
@@ -37,6 +37,19 @@ describe('react.backbone', function() {
       expect(header.getDOMNode().textContent).toEqual('David');
     });
 
+    it('renders model on render event', function() {
+      var user = new Backbone.Model({name: "Clay"});
+      var userViewRef = UserView({model: user});
+      var userView = TestUtils.renderIntoDocument(userViewRef);
+      user.set("name", "David", {silent: true});
+
+      var header = TestUtils.findRenderedDOMComponentWithTag(userView, 'h1');
+      expect(header.getDOMNode().textContent).toEqual('Clay');
+
+      user.trigger('render');
+      expect(header.getDOMNode().textContent).toEqual('David');
+    });
+
     describe("with changeOptions", function() {
       var UserView = React.createBackboneClass({
         changeOptions: "change:name",
@@ -100,7 +113,6 @@ describe('react.backbone', function() {
     });
 
     it('renders collection on adding', function() {
-
       var usersList = new Backbone.Collection([{name: "Clay"}, {name: "David"}]);
       var usersListViewRef = UsersListView({collection: usersList});
       var usersListView = TestUtils.renderIntoDocument(usersListViewRef);
@@ -109,6 +121,25 @@ describe('react.backbone', function() {
       jest.runOnlyPendingTimers();
 
       var list = TestUtils.findRenderedDOMComponentWithTag(usersListView, 'ul');
+      expect(list.getDOMNode().childNodes.length).toEqual(3);
+      expect(list.getDOMNode().childNodes[2].textContent).toEqual("Jack");
+    });
+
+    it('renders collection on render event', function() {
+      var usersList = new Backbone.Collection([{name: "Clay"}, {name: "David"}]);
+      var usersListViewRef = UsersListView({collection: usersList});
+      var usersListView = TestUtils.renderIntoDocument(usersListViewRef);
+
+      usersList.add({name: "Jack"}, {silent: true});
+      jest.runOnlyPendingTimers();
+
+      var list = TestUtils.findRenderedDOMComponentWithTag(usersListView, 'ul');
+      expect(list.getDOMNode().childNodes.length).toEqual(2);
+      expect(list.getDOMNode().childNodes[2]).toBeUndefined();
+
+      usersList.trigger('render');
+      jest.runOnlyPendingTimers();
+
       expect(list.getDOMNode().childNodes.length).toEqual(3);
       expect(list.getDOMNode().childNodes[2].textContent).toEqual("Jack");
     });

--- a/react.backbone.js
+++ b/react.backbone.js
@@ -14,12 +14,12 @@
     'use strict';
 
     var collectionBehavior = {
-        changeOptions: 'add remove reset sort',
+        changeOptions: 'add remove reset sort render',
         updateScheduler: function(func) { return _.debounce(func, 0); }
     };
 
     var modelBehavior = {
-        changeOptions: 'change',
+        changeOptions: 'change render',
         //note: if we debounce models too we can no longer use model attributes
         //as properties to react controlled components due to https://github.com/facebook/react/issues/955
         updateScheduler: _.identity


### PR DESCRIPTION
That is something that I always add to my local version of ReactBackbone and thought that it could very well be part of the official repo.

Sometimes, you just want to trigger a rerender of a ReactBackbone component without triggering a `change` event (i.e. if your model is listening to `change` and you absolutely don’t want that action to be fired). Other times you may want to `Model#set` with  `silent: true` and render the changes later for performance sake.

Also useful for collections that don’t have a `change` event per se.
