### PR TITLE
Configuration Function for Collection Behavior Test

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,18 @@ React.BackboneMixin({
 });
 ```
 
+If your Collection or Model class does not inherit directly from Backbone.Model 
+or Backbone.Collection, you may customize the behavior on a library level by
+overriding the React.BackboneMixin.ConsiderAsCollection function.
+
+Return `true` if the object passed should behave as a collection.
+
+```javascript
+React.BackboneMixin.ConsiderAsCollection = function (modelOrCollection) {
+  return modelOrCollection instanceof Backbone.Collection || modelOrCollection instanceof MyCustomCollection;
+}
+```
+
 ### Installation
 
 Either download `react.backbone.js` or install the `react.backbone` package on

--- a/react.backbone.js
+++ b/react.backbone.js
@@ -30,7 +30,7 @@
             return;
         }
 
-        var behavior = modelOrCollection instanceof Backbone.Collection ? collectionBehavior : modelBehavior;
+        var behavior = React.BackboneMixin.ConsiderAsCollection(modelOrCollection) ? collectionBehavior : modelBehavior;
 
         var triggerUpdate = behavior.updateScheduler(function() {
             if (component.isMounted()) {
@@ -100,6 +100,10 @@
             unsubscribe(this, modelOrCollection(this.props));
         }
       };
+    };
+
+    React.BackboneMixin.ConsiderAsCollection = function (modelOrCollection) {
+        return modelOrCollection instanceof Backbone.Collection;
     };
 
     React.BackboneViewMixin = {


### PR DESCRIPTION
* Adds React.BackboneMixin.ConsiderAsCollection
* Allows for use of non-standard Backbone compatible objects

Resolves #32 