### PR TITLE
Remove `el()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ React.BackboneMixin({
 });
 ```
 
-If your Collection or Model class does not inherit directly from Backbone.Model 
+If your Collection or Model class does not inherit directly from Backbone.Model
 or Backbone.Collection, you may customize the behavior on a library level by
 overriding the React.BackboneMixin.ConsiderAsCollection function.
 
@@ -158,4 +158,5 @@ define(['backbone', 'react', 'react.backbone'], function(Backbone, React) {
 });
 ```
 
-Version 0.7.0 supports React >0.14 and Backbone >1.0; for React <0.14, check out versions 0.6.0 and prior
+Version 0.7.0 supports React >0.14 and Backbone >1.0; for React <0.14, check out versions 0.6.0 and prior.
+React Native is also supported, but only works with npm v3 (otherwise it will use the wrong React dependency).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react.backbone",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": "Clay Allsopp <clay.allsopp@gmail.com>",
   "scripts": {
     "test": "jest"
@@ -29,7 +29,6 @@
   },
   "peerDependencies": {
     "react": ">=0.14.x <1.x.x",
-    "react-dom": ">=0.14.x <1.x.x",
     "backbone": "1.x.x",
     "underscore": ">=1.2.x"
   },

--- a/react.backbone.js
+++ b/react.backbone.js
@@ -1,15 +1,15 @@
 (function(root, factory) {
     if (typeof exports === 'object') {
         // CommonJS
-        module.exports = factory(require('backbone'), require('react'), require('react-dom'), require('underscore'));
+        module.exports = factory(require('backbone'), require('react'), require('underscore'));
     } else if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
-        define(['backbone', 'react', 'react-dom', 'underscore'], factory);
+        define(['backbone', 'react', 'underscore'], factory);
     } else {
         // Browser globals
-        root.amdWeb = factory(root.Backbone, root.React, root.ReactDOM, root._);
+        root.amdWeb = factory(root.Backbone, root.React, root._);
     }
-}(this, function(Backbone, React, ReactDOM,  _) {
+}(this, function(Backbone, React,  _) {
 
     'use strict';
 
@@ -122,10 +122,6 @@
         collection: function() {
             return this.getCollection();
         },
-
-        el: function() {
-            return this.isMounted() && ReactDOM.findDOMNode(this);
-        }
     };
 
     React.createBackboneClass = function(spec) {


### PR DESCRIPTION
This was the only method that had a dependency on react-dom, and wasn't tested or documented. Without react-dom React Native is also supported (only with npm v3 though).